### PR TITLE
Serve directory index files inline instead of redirecting

### DIFF
--- a/statiq.go
+++ b/statiq.go
@@ -168,13 +168,16 @@ func (h *StatiqHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Try to serve an index file
+		// Try to serve an index file inline at the requested URL.
+		// Redirecting to the index file path would change the URL bar to
+		// `/foo/index.html`, which breaks SPA routers that match on the
+		// canonical path (`/foo/`).
 		for _, index := range h.indexFiles {
-			indexPath := path.Join(upath, index)  // Use path.Join for URL paths
+			indexPath := path.Join(upath, index)
 			indexFile, err := h.root.Open(indexPath)
 			if err == nil {
 				indexFile.Close()
-				localRedirect(w, r, indexPath)
+				h.serveFile(w, r, filepath.Join(h.rootPath, indexPath))
 				return
 			}
 		}

--- a/statiq.go
+++ b/statiq.go
@@ -2,6 +2,7 @@ package statiq
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -175,11 +176,24 @@ func (h *StatiqHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		for _, index := range h.indexFiles {
 			indexPath := path.Join(upath, index)
 			indexFile, err := h.root.Open(indexPath)
-			if err == nil {
-				indexFile.Close()
-				h.serveFile(w, r, filepath.Join(h.rootPath, indexPath))
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				if os.IsPermission(err) {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+				} else {
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				}
 				return
 			}
+			stat, statErr := indexFile.Stat()
+			indexFile.Close()
+			if statErr != nil || stat.IsDir() {
+				continue
+			}
+			h.serveFile(w, r, filepath.Join(h.rootPath, indexPath))
+			return
 		}
 
 		// If directory listing is disabled, return 404

--- a/statiq.go
+++ b/statiq.go
@@ -189,7 +189,15 @@ func (h *StatiqHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			stat, statErr := indexFile.Stat()
 			indexFile.Close()
-			if statErr != nil || stat.IsDir() {
+			if statErr != nil {
+				if os.IsPermission(statErr) {
+					http.Error(w, "Forbidden", http.StatusForbidden)
+				} else {
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				}
+				return
+			}
+			if stat.IsDir() {
 				continue
 			}
 			h.serveFile(w, r, filepath.Join(h.rootPath, indexPath))

--- a/statiq_test.go
+++ b/statiq_test.go
@@ -143,39 +143,28 @@ func TestIndexFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	
-	// Test directory request with trailing slash
+	// Directory requests with a trailing slash should serve the index file
+	// inline (200 OK) so the browser's URL stays at the canonical directory
+	// path — redirecting to `/subdir/custom.html` breaks SPA routers that
+	// match on the canonical path.
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost/subdir/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, req)
-	
-	if recorder.Code != http.StatusMovedPermanently {
-		t.Errorf("Expected redirect for directory, got status code %d", recorder.Code)
-	}
-	
-	// Get the redirect location and follow it
-	location := recorder.Header().Get("Location")
-	if location != "/subdir/custom.html" {
-		t.Errorf("Expected redirect to /subdir/custom.html, got %s", location)
-	}
-	
-	req, err = http.NewRequestWithContext(context.Background(), http.MethodGet, "http://localhost"+location, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	
-	recorder = httptest.NewRecorder()
-	handler.ServeHTTP(recorder, req)
-	
+
 	if recorder.Code != http.StatusOK {
-		t.Errorf("Expected 200 OK, got %d", recorder.Code)
+		t.Errorf("Expected 200 OK for directory with index, got %d", recorder.Code)
 	}
-	
+
 	if recorder.Body.String() != indexContent {
 		t.Errorf("Expected index content, got %s", recorder.Body.String())
+	}
+
+	if loc := recorder.Header().Get("Location"); loc != "" {
+		t.Errorf("Expected no redirect Location header, got %s", loc)
 	}
 }
 


### PR DESCRIPTION
## Summary

I ran into a small issue while using statiq with an SPA.

When a request hits a directory with an index file (say `/blog/post/` → `/blog/post/index.html`), statiq currently 301s to the index file path. That works good for static sites, but it breaks SPAs that match routes on the canonical directory URL. Once the redirect lands, the address bar reads `/blog/post/index.html` and the client-side router can't find a match.

The patch serves the index file inline at the original URL, similar to how `http.FileServer` and nginx's `try_files $uri/ $uri/index.html` handle it.

It can also go behind a config flag if that fits the project better.

## Changes
- `statiq.go`: serve index files inline instead of redirecting
- `statiq_test.go`: updated `TestIndexFiles` to cover the new behavior

## Tested
- [x] `go test ./...` passes
- [x] Request to `/somedir/` returns the `index.html` content with the URL unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory requests ending with a trailing slash now serve the configured index file directly (HTTP 200) instead of issuing an HTTP redirect, removing an extra request hop and handling missing/permission errors appropriately.
* **Tests**
  * Updated tests to expect direct serving of index files for trailing-slash directory requests (no Location redirect).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hhftechnology/statiq/pull/9)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->